### PR TITLE
fix reglink generation for existing users

### DIFF
--- a/controllers/accounts.js
+++ b/controllers/accounts.js
@@ -11,7 +11,7 @@ const moment = require('moment');
 moment.locale('de');
 
 const getTableActions = (item, path) => {
-    return [
+    let tableActions = [
         {
             link: path + item._id,
             class: 'btn-edit',
@@ -33,6 +33,15 @@ const getTableActions = (item, path) => {
             title: 'Nutzerinformationen anzeigen'
         }
     ];
+    if (item.username && item.userId) {
+        tableActions.push({
+            link: `${path.replace("accounts","users")}registrationlink/${item.userId}?save=true&patchUser=true`,
+            class: 'btn-reglink',
+            icon: 'share-alt',
+            title: 'Registrierungslink generieren'
+        });
+    }
+    return tableActions;
 };
 
 /*

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -42,7 +42,7 @@ const getTableActions = (item, path) => {
     ];
     if (item.email) {
         tableActions.push({
-            link: path + 'registrationlink/' + item._id,
+            link: `${path}registrationlink/${item._id}?save=true&patchUser=true`,
             class: 'btn-reglink',
             icon: 'share-alt',
             title: 'Registrierungslink generieren'

--- a/views/accounts/accounts.hbs
+++ b/views/accounts/accounts.hbs
@@ -31,5 +31,10 @@
                 {{> "lib/components/delete-form-user"}}
             {{/content}}
         {{/embed}}
+        {{#embed "lib/components/modal-form" class="reglink-modal"}}
+            {{#content "fields"}}
+                {{> "users/forms/form-invitation"}}
+            {{/content}}
+        {{/embed}}
     {{/content}}
 {{/extend}}


### PR DESCRIPTION
Problem: Registrierungslink generieren in der Nutzerverwaltung erzeugt zwar einen neuen Link mit neuem Hash, schreibt den Hash aber noch nicht in den Nutzer.
Ursache: Aufruf des Reglink Service fehlten ein paar Infos.
Lösung: Linkerstellung sollte jetzt den neuen Hash in den Nutzer schreiben, der Link führt dann zur Registration und füllt dort Vor- und Nachname sowie E-Mail vor.