### PR TITLE
Wording: Rename storage provider in school administration

### DIFF
--- a/controllers/schools.js
+++ b/controllers/schools.js
@@ -49,9 +49,9 @@ const createBucket = (req, res, next) => {
         });
 };
 
-const getStorageProviders = (res) => {
+const getStorageProviders = () => {
 	return [
-		{ label: res.locals.theme.short_title, value: 'awsS3' }
+		{ label: process.env.SC_SHORT_TITLE, value: 'awsS3' }
 	];
 };
 
@@ -176,7 +176,7 @@ router.all('/', function (req, res, next) {
             }
         }).then(data => {
 
-            let provider = getStorageProviders(res);
+            let provider = getStorageProviders();
             provider = (provider || []).map(prov => {
                 if (prov.value == data.fileStorageType) {
                     return Object.assign(prov, {

--- a/controllers/schools.js
+++ b/controllers/schools.js
@@ -49,14 +49,12 @@ const createBucket = (req, res, next) => {
         });
 };
 
-const getStorageProviders = () => {
-	return [
-		{ 
-			label: process.env.SC_SHORT_TITLE,
-			value: 'awsS3',
-		}
-	];
-};
+const getStorageProviders = () => [
+	{
+		label: process.env.SC_SHORT_TITLE,
+		value: 'awsS3',
+	},
+];
 
 const getCreateHandler = (service) => {
     return function (req, res, next) {

--- a/controllers/schools.js
+++ b/controllers/schools.js
@@ -49,10 +49,10 @@ const createBucket = (req, res, next) => {
         });
 };
 
-const getStorageProviders = () => {
-    return [
-        {label: 'AWS S3', value: 'awsS3'}
-    ];
+const getStorageProviders = (res) => {
+	return [
+		{ label: res.locals.theme.short_title, value: 'awsS3' }
+	];
 };
 
 const getCreateHandler = (service) => {
@@ -176,7 +176,7 @@ router.all('/', function (req, res, next) {
             }
         }).then(data => {
 
-            let provider = getStorageProviders();
+            let provider = getStorageProviders(res);
             provider = (provider || []).map(prov => {
                 if (prov.value == data.fileStorageType) {
                     return Object.assign(prov, {

--- a/controllers/schools.js
+++ b/controllers/schools.js
@@ -51,7 +51,10 @@ const createBucket = (req, res, next) => {
 
 const getStorageProviders = () => {
 	return [
-		{ label: process.env.SC_SHORT_TITLE, value: 'awsS3' }
+		{ 
+			label: process.env.SC_SHORT_TITLE,
+			value: 'awsS3',
+		}
 	];
 };
 


### PR DESCRIPTION
kein Ticket
"AWS S3" als Storage Provider nicht nicht mehr korrekt und wird umbenannt zum Theme Name: 
![image](https://user-images.githubusercontent.com/6624503/57441392-24ad6300-724a-11e9-8b75-d576b43960e0.png)
Server-PR: https://github.com/schul-cloud/schulcloud-client/pull/1184