### PR TITLE
Remove iframe option from tools

### DIFF
--- a/controllers/tools.js
+++ b/controllers/tools.js
@@ -37,10 +37,10 @@ const sanitizeTool = (req, create=false) => {
   req.body.key = req.body.key || "none";
   req.body.isLocal = req.body.isLocal || false;
   req.body.isTemplate = true;
-  if(create || !req.body.isLocal) {
+  if(create || !req.body.isLocal) { // non-local (LTI) tools can be updated forever, local (OAuth2) only during creation
     req.body.oAuthClientId = req.body.oAuthClientId || "";
   } else {
-    req.body.oAuthClientId = undefined;
+    req.body.oAuthClientId = undefined; // undefine the property prohibits database update
   }
   return req;
 }

--- a/controllers/tools.js
+++ b/controllers/tools.js
@@ -36,7 +36,6 @@ const sanitizeTool = (req, create=false) => {
   req.body.secret = req.body.secret || "none";
   req.body.key = req.body.key || "none";
   req.body.isLocal = req.body.isLocal || false;
-  req.body.useIframePseudonym = req.body.useIframePseudonym || false;
   req.body.isTemplate = true;
   if(req.body.isLocal && create) {
     req.body.oAuthClientId = req.body.key;

--- a/controllers/tools.js
+++ b/controllers/tools.js
@@ -37,8 +37,10 @@ const sanitizeTool = (req, create=false) => {
   req.body.key = req.body.key || "none";
   req.body.isLocal = req.body.isLocal || false;
   req.body.isTemplate = true;
-  if(req.body.isLocal && create) {
-    req.body.oAuthClientId = req.body.key;
+  if(create || !req.body.isLocal) {
+    req.body.oAuthClientId = req.body.oAuthClientId || "";
+  } else {
+    req.body.oAuthClientId = undefined;
   }
   return req;
 }
@@ -60,7 +62,7 @@ const getCreateHandler = (service) => {
       if(req.body.isLocal) {
         api(req).post('/oauth2/clients/', {
           json: {
-            "client_id": req.body.key,
+            "client_id": req.body.oAuthClientId,
             "client_name": req.body.name,
             "client_secret": req.body.secret,
             "redirect_uris": req.body.redirect_url.split(";"),
@@ -84,7 +86,7 @@ const getUpdateHandler = (service) => {
         api(req).patch('/' + service + '/' + req.params.id, {
             json: req.body
         }).then(data => {
-          if(data.oAuthClientId) {
+          if(data.isLocal) {
             api(req).put(`/oauth2/clients/${data.oAuthClientId}`, {
               json: {
                 "client_name": req.body.name,
@@ -108,7 +110,7 @@ const getUpdateHandler = (service) => {
 const getDetailHandler = (service) => {
     return function (req, res, next) {
         api(req).get('/' + service + '/' + req.params.id).then(data => {
-          if(data.oAuthClientId) {
+          if(data.isLocal) {
             api(req).get(`/oauth2/clients/${data.oAuthClientId}`).then(client => {
               data.key = data.oAuthClientId;
               data.secret = PASSWORD;
@@ -128,7 +130,7 @@ const getDetailHandler = (service) => {
 const getDeleteHandler = (service) => {
     return function (req, res, next) {
         api(req).delete('/' + service + '/' + req.params.id).then(data => {
-          if(data.oAuthClientId) {
+          if(data.isLocal) {
             api(req).delete(`/oauth2/clients/${data.oAuthClientId}`).then(_ => {
               res.redirect(req.header('Referer'));
             });

--- a/views/tools/forms/add-tool.hbs
+++ b/views/tools/forms/add-tool.hbs
@@ -8,8 +8,8 @@ Hinweis: Änderungen betreffen keine bereits instanzierten Tools in Kursen, ledi
     <input type="text" name="url" id="url" class="form-control" placeholder="https://app.com" required>
 </div>
 <div class="form-group">
-    <label class="control-label" for="key">Key / OAuth2-Client-Id</label>
-    <input type="text" name="key" id="key" required="required" class="form-control" placeholder="">
+    <label class="control-label" for="key">Key</label>
+    <input type="text" name="key" id="key" class="form-control" placeholder="">
 </div>
 <div class="form-group">
     <label class="control-label" for="secret">Secret</label>
@@ -27,6 +27,10 @@ Hinweis: Änderungen betreffen keine bereits instanzierten Tools in Kursen, ledi
             <option value="{{this.value}}">{{this.label}}</option>
         {{/each}}
     </select>
+</div>
+<div class="form-group">
+    <label class="control-label" for="key">OAuth- bzw. LTI-ClientId</label>
+    <input type="text" name="oAuthClientId" id="oAuthClientId" required="required" class="form-control" placeholder="">
 </div>
 <div class="form-group">
     <label class="control-label" for="isLocal">Ist ein OAuth2-Tool?</label>

--- a/views/tools/forms/add-tool.hbs
+++ b/views/tools/forms/add-tool.hbs
@@ -62,7 +62,3 @@ Hinweis: Änderungen betreffen keine bereits instanzierten Tools in Kursen, ledi
         {{/each}}
     </select>
 </div>
-<div class="form-group">
-    <label class="control-label" for="useIframePseudonym">Iframe-Subjects (zukunftsunsicher)</label>
-    <input type="checkbox" name="useIframePseudonym" id="useIframePseudonym" class="form-control">
-</div>


### PR DESCRIPTION
Related to
 https://github.com/schul-cloud/schulcloud-server/pull/840
https://github.com/schul-cloud/schulcloud-client/pull/1449

Removed option field for useIframePseudonym -> it is sent by default in a seperate field now on authentication:

![image](https://user-images.githubusercontent.com/22246303/66701784-9d847f80-ed00-11e9-8de1-e00bfbcf13fe.png)