### PR TITLE
Gulp wieder ins Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV NODE_PATH=/opt/node_modules
 COPY . /app
 ENV SC_THEME=default
 ENV TZ=Europe/Berlin
-RUN chown -R 1000:1000 /app
+RUN gulp && chown -R 1000:1000 /app
 
 EXPOSE 3033
 CMD ["npm", "run", "start"]

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.12.0",
   "private": true,
   "scripts": {
-    "start": "gulp && node ./bin/www",
+    "start": "node ./bin/www",
     "watch": "nodemon --watch ./ --watch views/ --watch controllers/ --watch build/ --ext js,hbs ./bin/www",
     "debug": "nodemon --inspect=0.0.0.0:9311 --watch controllers/ --watch helpers/ --watch views/ --ext js,hbs ./bin/www",
     "lint": "eslint ./bin ./controllers ./helpers ./test ./api.js ./app.js --ext .js --fix",


### PR DESCRIPTION
Wenn das Gulp schon im Dockerbuild läuft, krepiert das SHD nicht beim Start mit:

Mar 11 07:33:10 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: npm ERR! Failed at the superhero-dashboard@0.12.0 start script.
Mar 11 07:33:10 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
Mar 11 07:33:11 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: 
Mar 11 07:33:11 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: npm ERR! A complete log of this run can be found in:
Mar 11 07:33:11 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: npm ERR!     /root/.npm/_logs/2020-03-11T06_33_10_766Z-debug.log
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: 
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: > superhero-dashboard@0.12.0 start /app
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: > gulp && node ./bin/www
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: 
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: /app/node_modules/node-sass/lib/binding.js:15
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]:       throw new Error(errors.missingBinary());
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]:       ^
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: 
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: Error: Missing binding /app/node_modules/node-sass/vendor/linux_musl-x64-64/binding.node
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: Node Sass could not find a binding for your current environment: Linux/musl 64-bit with Node.js 10.x
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: 
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: Found bindings for the following environments:
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]:   - Linux 64-bit with Node.js 8.x
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: 
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: 
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: This usually happens because your environment has changed since running `npm install`.
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: Run `npm rebuild node-sass` to download the binding for your current environment.
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]:     at module.exports (/app/node_modules/node-sass/lib/binding.js:15:13)
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]:     at Object.<anonymous> (/app/node_modules/node-sass/lib/index.js:14:35)
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]:     at Module._compile (internal/modules/cjs/loader.js:778:30)
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]:     at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]:     at Module.load (internal/modules/cjs/loader.js:653:32)
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]:     at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]:     at Function.Module._load (internal/modules/cjs/loader.js:585:3)
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]:     at Module.require (internal/modules/cjs/loader.js:692:17)
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]:     at require (internal/modules/cjs/helpers.js:25:18)
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]:     at Object.<anonymous> (/app/node_modules/gulp-sass/index.js:162:21)
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: npm ERR! code ELIFECYCLE
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: npm ERR! errno 1
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: npm ERR! superhero-dashboard@0.12.0 start: `gulp && node ./bin/www`
Mar 11 07:33:19 test.schul-cloud.org docker_test-schul-cloud_superhero-dashboard[10420]: npm ERR! Exit status 1